### PR TITLE
Форматирование geo-координат

### DIFF
--- a/source/Yandex/Geo/Api.php
+++ b/source/Yandex/Geo/Api.php
@@ -132,7 +132,7 @@ class Api
     {
         $longitude = (float)$longitude;
         $latitude = (float)$latitude;
-        $this->_filters['geocode'] = sprintf('%f,%f', $longitude, $latitude);
+        $this->_filters['geocode'] = sprintf('%F,%F', $longitude, $latitude);
         return $this;
     }
 


### PR DESCRIPTION
Форматировать координаты независимо от настроек локали (LC_NUMERIC - может быть ',' или '.').
Использование %F позволяет форматировать без учета настроек локали, то есть используя "." для float