### PR TITLE
Нет выброса исключений при ошибке API

### DIFF
--- a/source/Yandex/Geo/Api.php
+++ b/source/Yandex/Geo/Api.php
@@ -89,6 +89,9 @@ class Api
             $msg = sprintf('Can\'t load data by url: %s', $apiUrl);
             throw new \Yandex\Geo\Exception($msg);
         }
+        if (!empty($data['error'])) {
+            throw new \Yandex\Geo\Exception\MapsError($data['error']['message'], $data['error']['code']);
+        }
 
         $this->_response = new \Yandex\Geo\Response($data);
 

--- a/source/Yandex/Geo/Exception/MapsError.php
+++ b/source/Yandex/Geo/Exception/MapsError.php
@@ -1,0 +1,12 @@
+<?php
+namespace Yandex\Geo\Exception;
+
+/**
+ * Class ServerError
+ * @package Yandex\Geo\Exception
+ * @license The MIT License (MIT)
+ */
+class MapsError extends \Yandex\Geo\Exception
+{
+
+}


### PR DESCRIPTION
Столкнулся с проблемой, что библиотека не выбрасывает исключение если произошла ошибка по типу "Превышен лимит запросов" или, например "Неправильный ключ API". Это не очень удобно, не правильно обрабатывать результаты работы API.
Исправил это дополнительной обработкой ответа и выбросом исключения \Yandex\Geo\Exception\MapsError.