### PR TITLE
add KIND_AREA

### DIFF
--- a/source/Yandex/Geo/Api.php
+++ b/source/Yandex/Geo/Api.php
@@ -17,6 +17,8 @@ class Api
     const KIND_METRO = 'metro';
     /** район города */
     const KIND_DISTRICT = 'district';
+    /** район области */
+    const KIND_AREA = 'area';
     /** населенный пункт (город/поселок/деревня/село/...) */
     const KIND_LOCALITY = 'locality';
     /** русский (по умолчанию) */


### PR DESCRIPTION
Не мог получить координаты для некоторых АО Москвы, т. к. они являлись не `district`, а `area`, а в \Yandex\Geo\Api не была указана нужная константа