### PR TITLE
Нет выброса исключений при новом типе ошибок

### DIFF
--- a/source/Yandex/Geo/Api.php
+++ b/source/Yandex/Geo/Api.php
@@ -92,6 +92,9 @@ class Api
         if (!empty($data['error'])) {
             if (is_array($data['error'])) {
                 throw new \Yandex\Geo\Exception\MapsError($data['error']['message'], $data['error']['code']);
+            } else if (!empty($data['message'])) {
+                $code = !empty($data['statusCode']) ? $data['statusCode'] : 0;
+                throw new \Yandex\Geo\Exception\MapsError($data['message'], $code);
             } else {
                 throw new \Yandex\Geo\Exception\MapsError($data['error']);
             }

--- a/source/Yandex/Geo/Api.php
+++ b/source/Yandex/Geo/Api.php
@@ -90,7 +90,11 @@ class Api
             throw new \Yandex\Geo\Exception($msg);
         }
         if (!empty($data['error'])) {
-            throw new \Yandex\Geo\Exception\MapsError($data['error']['message'], $data['error']['code']);
+            if (is_array($data['error'])) {
+                throw new \Yandex\Geo\Exception\MapsError($data['error']['message'], $data['error']['code']);
+            } else {
+                throw new \Yandex\Geo\Exception\MapsError($data['error']);
+            }
         }
 
         $this->_response = new \Yandex\Geo\Response($data);


### PR DESCRIPTION
Исправление моего давнего [пул реквеста](https://github.com/yandex-php/php-yandex-geo/pull/18). Сейчас Яндекс может выбросить ещё один тип массива с ошибкой.

Например:
```
array(3) {
  ["statusCode"]=>
  int(403)
  ["error"]=>
  string(9) "Forbidden"
  ["message"]=>
  string(11) "Invalid key"
}
```